### PR TITLE
Adds GitHub Actions workflow link to badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <div align="center">🦉 Hoot</div>
 
-![Haskell CI](https://github.com/i-am-tom/hoot/workflows/Haskell%20CI/badge.svg?branch=main)
+[<img alt="build status" src="https://github.com/i-am-tom/hoot/workflows/Haskell%20CI/badge.svg?branch=main">](https://github.com/i-am-tom/hoot/actions?query=workflow%3A%22Haskell+CI%22)
 
 Lots of static site generators exist, but most of them squarely target _expert
 users_. They rely on you understanding __HTML__ or __Markdown__, and usually

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <div align="center">🦉 Hoot</div>
 
-[<img alt="build status" src="https://github.com/i-am-tom/hoot/workflows/Haskell%20CI/badge.svg?branch=main">](https://github.com/i-am-tom/hoot/actions?query=workflow%3A%22Haskell+CI%22)
+[<img alt="Haskell CI" src="https://github.com/i-am-tom/hoot/workflows/Haskell%20CI/badge.svg?branch=main">](https://github.com/i-am-tom/hoot/actions?query=workflow%3A%22Haskell+CI%22)
 
 Lots of static site generators exist, but most of them squarely target _expert
 users_. They rely on you understanding __HTML__ or __Markdown__, and usually


### PR DESCRIPTION
I'm just here for that _sweet_ Hacktoberfest shirt, byeeee.

---

More seriously, it does bother me somewhat when CI badges don't link to the workflow they're referencing and that's not too difficult to fix up here.

~Looking at the diff I just realized that I let a copy/paste error slip by in the the `img alt`; I can change that back to "Haskell CI" in a sec.~ Done.