### PR TITLE
:sparkles: Handle IDs and Identified entities

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
     - name: Run tests
-      run: cabal test all
+      run: cabal test --enable-tests --enable-benchmarks all

--- a/hoot.cabal
+++ b/hoot.cabal
@@ -7,9 +7,14 @@ maintainer:            i.am.tom.harding@gmail.com
 build-type:            Simple
 
 library
-  exposed-modules:     Control.Monad.Logger
+  exposed-modules:     Control.Monad.Logger,
+                       Hoot.Contentful.Id
   build-depends:       base >= 4.14 && < 4.15,
-                       transformers >= 0.5 && < 0.6
+                       aeson >= 1.5 && < 1.6,
+                       hashable >= 1.3 && < 1.4,
+                       text >= 1.2 && < 1.3,
+                       transformers >= 0.5 && < 0.6,
+                       unordered-containers >= 0.2 && < 0.3
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall -Wextra
@@ -26,13 +31,15 @@ test-suite hoot-test
   ghc-options:         -Wall -Wextra
   hs-source-dirs:      test
   main-is:             Driver.hs
+  other-modules:       Control.Monad.LoggerTest,
+                       Hoot.Contentful.IdTest
   build-depends:       hoot,
                        aeson >= 1.5 && < 1.6,
                        base >= 4.14 && < 4.15,
                        hedgehog >= 1.0 && < 1.1,
                        tasty >= 1.2 && < 1.3,
-                       tasty-discover >= 4.2 && < 4.3,
                        tasty-hedgehog >= 1.0 && < 1.1,
                        tasty-hspec >= 1.1 && < 1.2,
-                       transformers >= 0.5 && < 0.6,
-                       vector >= 0.12 && < 0.13
+                       tasty-quickcheck >= 0.10 && < 0.11,
+                       text >= 1.2 && < 1.3,
+                       unordered-containers >= 0.2 && < 0.3

--- a/src/Hoot/Contentful/Id.hs
+++ b/src/Hoot/Contentful/Id.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+module Hoot.Contentful.Id where
+
+import Data.Aeson ((.:), FromJSON (..), Value)
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (Parser)
+import Data.Hashable (Hashable)
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import Data.Kind (Type)
+import Data.String (IsString)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Prelude hiding (id)
+
+-- | A Contentful ID is an identifier that we can use to reference entries or
+-- assets. It is indexed by the type of entity that it references, to make sure
+-- that they can't be mixed up.
+newtype Id (entity :: Type)
+  = Id { toText :: Text }
+  deriving stock (Eq, Generic, Ord, Show)
+  deriving newtype (FromJSON, Hashable, IsString)
+
+-- | An /identified/ entity is an entity that has an identifier. Specifically,
+-- we expect the identifier to be in the entity's JSON under @.sys.id@.
+data Identified (entity :: Type)
+  = Identified
+      { id     :: Id entity
+      , entity :: entity
+      }
+  deriving stock (Eq, Generic, Ord, Show)
+  deriving anyclass (Hashable)
+
+-- | Convert an 'Identified' entity into a pair of its identifier and the
+-- entity itself. This mostly exists for internal use in 'parseJSON', and
+-- probably isn't useful anywhere else.
+toPair :: Identified x -> (Id x, x)
+toPair Identified{..} = ( id, entity )
+
+instance FromJSON x => FromJSON (Identified x) where
+  parseJSON :: Value -> Parser (Identified x)
+  parseJSON json = do
+    let parseIdentifier :: Value -> Parser (Id entity)
+        parseIdentifier = Aeson.withObject "Entity" \asset ->
+          asset .: "sys" >>= Aeson.withObject "sys" \sys ->
+            sys .: "id"
+
+    id     <- parseIdentifier json
+    entity <- parseJSON json
+
+    pure Identified{..}
+
+-- | An entity catalogue is a 'HashMap' in which the keys are 'Id' references
+-- to their entity values. For our purposes, entity catalogues are likely to be
+-- filled with @Entry@, @Asset@, and @ContentType@ values.
+newtype Catalogue (entity :: Type)
+  = Catalogue { toHashMap :: HashMap (Id entity) entity }
+  deriving stock (Eq, Generic, Ord, Show)
+  deriving anyclass (Hashable)
+
+instance FromJSON x => FromJSON (Catalogue x) where
+  parseJSON :: Value -> Parser (Catalogue x)
+  parseJSON = fmap (Catalogue . HashMap.fromList . map toPair) . parseJSON

--- a/test/Control/Monad/LoggerTest.hs
+++ b/test/Control/Monad/LoggerTest.hs
@@ -77,4 +77,5 @@ hprop_PureT_composition = property do
 
 hprop_PureT_homomorphism :: Property
 hprop_PureT_homomorphism = property do
-  log @PureT 3 `logging` show === log (show 3)
+  x <- forAll (Gen.int (Range.linear 0 1000))
+  log @PureT x `logging` show === log (show x)

--- a/test/Driver.hs
+++ b/test/Driver.hs
@@ -1,1 +1,1 @@
-{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display -optF --debug #-}
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display #-}

--- a/test/Hoot/Contentful/IdTest.hs
+++ b/test/Hoot/Contentful/IdTest.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+module Hoot.Contentful.IdTest where
+
+import Data.Aeson ((.=), FromJSON (..), Value (..))
+import Data.Aeson.Types (parseMaybe)
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Text as Text
+import Hoot.Contentful.Id (Catalogue (..), Id (..), Identified (..))
+import Prelude hiding (head, id)
+import Test.Tasty.QuickCheck (property)
+import Test.Tasty.Hspec
+import qualified Data.Aeson as Aeson
+
+spec_id :: Spec
+spec_id = describe "Hoot.Contentful.Id" do
+  it "Parses a single Identifier" $ property \(Text.pack -> x) ->
+    parseMaybe parseJSON (String x) `shouldBe`
+      Just (Id x)
+
+  it "Parses an identified entity" $ property \(Text.pack -> id) -> do
+    let entity :: Value
+        entity = Aeson.object [ "sys" .= Aeson.object [ "id" .= id ] ]
+
+    parseMaybe parseJSON entity `shouldBe`
+      Just Identified{ id = Id id, entity = entity }
+
+  it "Parses a Catalogue" $ property \(Text.pack -> id) -> do
+    let entity :: Value
+        entity = Aeson.object [ "sys" .= Aeson.object [ "id" .= id ] ]
+
+    parseMaybe parseJSON (Aeson.Array [ entity ]) `shouldBe`
+      Just (Catalogue (HashMap.singleton (Id id) entity))


### PR DESCRIPTION
This commit adds Contentful ID parsing. IDs are indexed by the type of entity that they reference.