### PR TITLE
:construction_worker: Rename "Haskell CI"

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,4 +1,4 @@
-name: Haskell CI
+name: Tests
 
 on:
   push:


### PR DESCRIPTION
This commit renames the CI test action to "Tests".