### PR TITLE
:memo: Add missing module headers

### DIFF
--- a/src/Control/Monad/Logger.hs
+++ b/src/Control/Monad/Logger.hs
@@ -2,6 +2,15 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE TypeFamilies #-}
+
+{-|
+Module      : Control.Monad.Logger
+Description : An interface and implementation for logging.
+Copyright   : (c) Tom Harding, 2020
+License     : MIT
+Maintainer  : i.am.tom.harding@gmail.com
+Stability   : experimental
+-}
 module Control.Monad.Logger where
 
 import Control.Monad.Trans.Reader (ReaderT (..))

--- a/src/Hoot/Contentful/Id.hs
+++ b/src/Hoot/Contentful/Id.hs
@@ -7,6 +7,15 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+
+{-|
+Module      : Hoot.Contentful.Id
+Description : A data type for Contentful IDs.
+Copyright   : (c) Tom Harding, 2020
+License     : MIT
+Maintainer  : i.am.tom.harding@gmail.com
+Stability   : experimental
+-}
 module Hoot.Contentful.Id where
 
 import Data.Aeson ((.:), FromJSON (..), Value)


### PR DESCRIPTION
A couple of the modules were missing headers and causing documentation warnings, so they've been added back in.